### PR TITLE
AR-151 Abstract hparam choices up to cmd line args. Add WandB logging

### DIFF
--- a/dam_with_parameter_list/train_top_k.py
+++ b/dam_with_parameter_list/train_top_k.py
@@ -6,14 +6,29 @@ from model_preparation import prepare_model
 from custom_trainer.dam_trainer_top_k import DAMTrainer  # Custom DAMTrainer
 from transformers import TrainingArguments, default_data_collator
 from modeling.dam import DAMBaseLayer
-
+import click
+import wandb
 
 # Environment variables
-os.environ['HF_TOKEN'] = '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' #'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'
+os.environ['HF_TOKEN'] = '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'
 os.environ['HF_HUB_ENABLE_HF_TRANSFER'] = '1'
 os.environ['HF_HOME'] = '/workspace/hf-cache'
 
-def main():
+# Command line arguments allow for WandB Sweep
+@click.command()
+@click.option("--temperature", default=2.0)
+@click.option("--weight_decay", default=0.005)
+@click.option("--learning_rate", default=1e-3)
+@click.option("--lr_scheduler_type", default="constant")
+@click.option("--use_kl", default=True)
+@click.option("--use_mse", default=False)
+@click.option("--use_entropy", default=False)
+@click.option("--lambda_coef", default=0.01)
+@click.option("--lambda_coef_l1", default=None)
+@click.option("--lambda_coef_l2", default=0.0001)
+def main(temperature, weight_decay, learning_rate, lr_scheduler_type,
+         use_kl, use_mse, use_entropy,
+         lambda_coef, lambda_coef_l1, lambda_coef_l2):
     # Model and dataset details
     base_model_name = "mistralai/Mistral-7B-v0.1" 
     model_name = "arcee-train/pplist-merged-untrained"
@@ -36,19 +51,19 @@ def main():
         eval_strategy="no",
         save_strategy="no",
         do_eval=False,
-        learning_rate=1e-3,
+        learning_rate=learning_rate,
         per_device_train_batch_size=2,
         per_device_eval_batch_size=1,
         num_train_epochs=1,
-        weight_decay=0.00,
-        lr_scheduler_type='constant',
+        weight_decay=weight_decay,
+        lr_scheduler_type=learning_rate,
         bf16=True,
         push_to_hub=False,
         remove_unused_columns=False,
         logging_dir='./logs',
         logging_steps=1,
         logging_strategy="steps",
-        report_to="tensorboard",
+        report_to="wandb",
         gradient_accumulation_steps=1
     )
 
@@ -60,19 +75,24 @@ def main():
         train_dataset=dataset,
         tokenizer=tokenizer,
         data_collator=default_data_collator,
-        lambda_coef=0.01,  # Example lambda coefficient for regularization
-        lambda_coef_l1=None,  # L1 regularization coefficient set to None
-        lambda_coef_l2=0.0001,  # L2 regularization coefficient
-        temperature=2.0,  # Example temperature for KL divergence
-        use_kl=False,
-        use_mse=True
+        lambda_coef=lambda_coef,  # Example lambda coefficient for regularization
+        lambda_coef_l1=lambda_coef_l1,  # L1 regularization coefficient set to None
+        lambda_coef_l2=lambda_coef_l2,  # L2 regularization coefficient
+        temperature=temperature,  # Example temperature for KL divergence
+        use_kl=use_kl,
+        use_mse=use_mse,
+        use_entropy=use_entropy,
     )
+
+    wandb.init(entity = 'arcee-ai', project="Dynamic Adaptive Merging")
 
     # Train the model
     trainer.train()
 
     # Save the trained model
     trainer.save_model()
+
+    wandb.finish()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Slightly restructured the compute_loss function, to enable easy toggling of MSE and KL loss, as well as entropy loss (as per AdaMerge). Saves each individual loss function to a loss_log dictionary, and logs the dictionary at the end of each compute_loss pass.

Moved most of the hparam arguments to be command line arguments in train_top_k.py, mainly so WandB sweeps can automatically optimise these for us.

Should be backwards compatible.