### PR TITLE
Add base model kl loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In this step, we assign a trainable coefficient for each column of each model's 
 
 
 ```bash
-python dam/merge.py mistralai/Mistral-7B-v0.1 augmxnt/shisa-gamma-7b-v1 WizardLM/WizardMath-7B-V1.1 arcee-train/Abel-7B-002-truncated-embeds --device cpu --output_path ./merged_model --use_embedding_layers --use_base_model --non_linearity tanh --merge_layernorms --repo_id arcee-train/pplist-merged-untrained-with-base-layernorm-embedding
+python dam/merge.py mistralai/Mistral-7B-v0.1 augmxnt/shisa-gamma-7b-v1 WizardLM/WizardMath-7B-V1.1 arcee-train/Abel-7B-002-truncated-embeds --device cpu --output_path ./merged_model --merge_embedding_layers --merge_layernorms --use_base_model --non_linearity "None"  --repo_id arcee-train/pplist-merged-untrained-with-base-layernorm-embedding
 ```
 
 #### Arguments:
@@ -25,10 +25,10 @@ python dam/merge.py mistralai/Mistral-7B-v0.1 augmxnt/shisa-gamma-7b-v1 WizardLM
 - `model_ids`: IDs of the models to merge. The linear layers from these models will be used.
 - `--output_path`: Path where the merged model will be saved.
 - `--device`: Device to use for computation (e.g., 'cpu', 'cuda').
-- `--use_embedding_layers`: If specified, embedding layers will be included in the merging process.
+- `--merge_embedding_layers`: If specified, embedding layers will be included in the merging process.
+- `--merge_layernorms`: If specified, layer normalization layers will be included in the merging process.
 - `--use_base_model`: If specified, trainable coefficients will also be added to the base model's linear layers. This is optional.
 - `--non_linearity`: Specifies the non-linearity to use in the DAMLinearLayer. Options are `tanh`, `sigmoid`, `relu`, or `None`.
-- `--merge_layernorms`: If specified, layer normalization layers will be included in the merging process.
 - `--repo_id`: Repository ID where the merged model will be pushed.shed.
 
 ### 2. Prepare the Dataset

--- a/dam/merge.py
+++ b/dam/merge.py
@@ -170,15 +170,15 @@ def main():
     parser.add_argument("model_ids", nargs='+', help="IDs of the models to merge (for linear layers)")
     parser.add_argument("--output_path", help="Path to save the merged model")
     parser.add_argument("--device", default="cpu", help="Device to use for computation (e.g., 'cpu', 'cuda')")
-    parser.add_argument("--use_embedding_layers", action='store_true', help="Include embedding layers in the merging process")
-    parser.add_argument("--use_base_model", action='store_true', help="Include base model's linear layers in the merging process")
-    parser.add_argument("--non_linearity", choices=['tanh', 'sigmoid', 'relu', None], default=None, help="Non-linearity to use in DAMLinearLayer")
+    parser.add_argument("--merge_embedding_layers", action='store_true', help="Include embedding layers in the merging process")
     parser.add_argument("--merge_layernorms", action='store_true', help="Include layer normalization layers in the merging process")
+    parser.add_argument("--use_base_model", action='store_true', help="Include base model's linear layers in the merging process")
+    parser.add_argument("--non_linearity", choices=['tanh', 'sigmoid', 'relu', 'None'], default=None, help="Non-linearity to use in DAMLinearLayer")
     parser.add_argument("--repo_id", required=True, help="Repository ID to push the merged model to")
 
     args = parser.parse_args()
 
-    merge_models(args.base_model_id, args.model_ids, args.output_path, args.device, args.use_base_model, args.non_linearity, args.use_embedding_layers, args.merge_layernorms, args.repo_id)
+    merge_models(args.base_model_id, args.model_ids, args.output_path, args.device, args.use_base_model, args.non_linearity, args.merge_embedding_layers, args.merge_layernorms, args.repo_id)
 
 if __name__ == "__main__":
     # os.environ['HF_TOKEN'] = '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'
@@ -190,4 +190,4 @@ if __name__ == "__main__":
     main()
 
 
-# python merge.py mistralai/Mistral-7B-v0.1 augmxnt/shisa-gamma-7b-v1  WizardLM/WizardMath-7B-V1.1 arcee-train/Abel-7B-002-truncated-embeds --device cpu --output_path ./merged_model --use_embedding_layers --use_base_model --non_linearity tanh --merge_layernorms --repo_id arcee-train/pplist-merged-untrained-with-base-layernorm-embedding
+# python merge.py mistralai/Mistral-7B-v0.1 augmxnt/shisa-gamma-7b-v1  WizardLM/WizardMath-7B-V1.1 arcee-train/Abel-7B-002-truncated-embeds --device cpu --output_path ./merged_model --merge_embedding_layers --use_base_model --non_linearity tanh --merge_layernorms --repo_id arcee-train/pplist-merged-untrained-with-base-layernorm-embedding


### PR DESCRIPTION
# Summary
This PR adds the `create_merge_dataset.py` and `train_dam.py` scripts by adding new command line arguments to support additional functionality.


1. **New Argument**:

   - `--base_model_dataset_name`: Allows users to specify a sample dataset name related to the base model. This 
#### Summary
This PR adds the `create_merge_dataset.py` and `train_dam.py` scripts by adding new command line arguments to support additional functionality.

#### Changes in `create_merge_dataset.py`
1. **New Argument**:
   - `--base_model_dataset_name`: Allows users to specify a sample dataset name related to the base model. This functionality is to use a dataset similar to the base model's training data, with the default name set to `reflex-ai/fineweb-ultra-mini`.

#### Changes in `train_dam.py`
1. **New Argument**:
   - `--loss_base_data_dist`: Computes the distribution difference between the base model and the merged model for the base data.

