### PR TITLE
 Trainable/Freezable Layer Norm , Embedding Coefficients and Seamless Logits Computation on-the-fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In this step, we assign a trainable coefficient for each column of each model's 
 
 
 ```bash
-python dam/merge.py mistralai/Mistral-7B-v0.1 augmxnt/shisa-gamma-7b-v1 WizardLM/WizardMath-7B-V1.1 arcee-train/Abel-7B-002-truncated-embeds --device cuda --output_path ./merged_model --merge_embedding_layers --merge_layernorms --use_base_model --non_linearity "None" --embedding_merge_random --linear_merge_random --repo_id arcee-train/untrained-merged-random-coeffs
+python dam/merge.py mistralai/Mistral-7B-v0.1 augmxnt/shisa-gamma-7b-v1 WizardLM/WizardMath-7B-V1.1 arcee-train/Abel-7B-002-truncated-embeds --device cuda --output_path ./merged_model  --use_base_model --non_linearity None --repo_id arcee-train/shamane-latest-untrained-merge
 ```
 
 #### Arguments:

--- a/dam/model_preparation.py
+++ b/dam/model_preparation.py
@@ -48,7 +48,8 @@ def prepare_model(model_name, cache_dir):
     print(f"Loading model from {model_name} with cache dir {cache_dir}")
     merged_model = MergedMistralForCausalLM.from_pretrained(model_name, torch_dtype=torch.bfloat16, device_map="auto", cache_dir=cache_dir)
     print_trainable_parameters(merged_model)
-    freeze_except_mergers(merged_model)
+    # We do not need this anymore since we freeze the params during the merging.
+    #freeze_except_mergers(merged_model)
     print("####################################")
     print_trainable_parameters(merged_model)
     

--- a/dam/modeling/dam.py
+++ b/dam/modeling/dam.py
@@ -41,13 +41,16 @@ class DAMBaseLayer(nn.Module):
 
         # Initialize the list of merging coefficients for each model's layer
         self.mergers = nn.ParameterList([Parameter(
-            torch.ones(in_features, dtype=dtype) * init_merger_values[i]
+            torch.ones(in_features, dtype=dtype) * init_merger_values[i],
+            requires_grad=use_in_merging  # Set requires_grad based on merging
         ) for i in range(num_models)])
 
-        # Store the flag indicating if this layer should be used in merging
-        self.use_in_merging = use_in_merging
-
     def compute_mergers_overlap(self, lambda_coef_overlap=0.000001):
+        # Check if any merger requires gradient
+        if all(not merger.requires_grad for merger in self.mergers):
+            device = self.mergers[0].device
+            return  torch.tensor(0.0, device=device)
+        
         # Initialize similarity loss
         overlap_loss = 0.0
         
@@ -70,8 +73,10 @@ class DAMBaseLayer(nn.Module):
 
     # Method to compute the similarity between merging coefficients
     def compute_mergers_similarity(self, lambda_coef=None):
-        if lambda_coef is None:
-            return 0.0
+        # Check if any merger requires gradient
+        if lambda_coef is None or all(not merger.requires_grad for merger in self.mergers):
+            device = self.mergers[0].device
+            return  torch.tensor(0.0, device=device)
     
         # Initialize similarity loss
         similarity_loss = 0.0
@@ -95,6 +100,10 @@ class DAMBaseLayer(nn.Module):
 
     # Method to compute L1 and L2 regularization on the merging coefficients
     def compute_mergers_L1_L2_reg(self, lambda_coef_l1=None, lambda_coef_l2=None):
+        # Check if any merger requires gradient
+        if all(not merger.requires_grad for merger in self.mergers):
+            return torch.tensor(0.0, device=self.mergers[0].device)
+
         device = self.mergers[0].device
         l1_reg = torch.tensor(0.0, device=device)
         l2_reg = torch.tensor(0.0, device=device)
@@ -109,11 +118,6 @@ class DAMBaseLayer(nn.Module):
 
         # Return the combined L1 and L2 regularization loss
         return l1_reg + l2_reg
-
-    # Method to unfreeze the merging coefficients so they can be trained
-    def unfreeze(self):
-        for merger in self.mergers:
-            merger.requires_grad = True
 
     # Method to apply the specified non-linearity to the merging coefficients
     def apply_non_linearity(self, tensor):
@@ -139,7 +143,7 @@ class DAMLinearLayer(DAMBaseLayer):
         non_linearity: str = 'tanh',  # Option to apply non-linearity   
         model_index: Optional[int] = None,
         use_random_init: bool = False,  # Flag to indicate if random initialization should be used
-        use_in_merging: bool = False,  # Flag to indicate if this layer should be used in merging
+        use_in_merging: bool = True,  # Flag to indicate if this layer should be used in merging
     ):
         super().__init__(
             in_features=in_features,
@@ -156,13 +160,14 @@ class DAMLinearLayer(DAMBaseLayer):
 
         # Initialize the list of weights for each model's layer
         self.weights = nn.ParameterList([Parameter(
-            torch.zeros(out_features, in_features, dtype=dtype) * self.init_merger_values[i]
+            torch.zeros(out_features, in_features, dtype=dtype),
+            requires_grad=False  # Freeze weights
         ) for i in range(num_models)])
 
         # If the layer has a bias, initialize the list of biases and bias mergers for each model
         if bias:
-            self.biases = nn.ParameterList([nn.Parameter(torch.zeros(out_features, dtype=dtype) * self.init_merger_values[i]) for i in range(num_models)])
-            self.bias_mergers = nn.ParameterList([nn.Parameter(torch.ones(1, dtype=dtype) * self.init_merger_values[i]) for i in range(num_models)])
+            self.biases = nn.ParameterList([nn.Parameter(torch.zeros(out_features, dtype=dtype), requires_grad=False) for i in range(num_models)])
+            self.bias_mergers = nn.ParameterList([nn.Parameter(torch.ones(1, dtype=dtype), requires_grad=use_in_merging) for i in range(num_models)])
 
     # Method to compute the combined weight for the merged layer
     def get_dam_weight(self):
@@ -226,7 +231,8 @@ class DAMEmbeddingLayer(DAMBaseLayer):
 
         # Initialize the list of embeddings for each model's layer as nn.Embedding
         self.embeddings = nn.ParameterList([Parameter(
-            torch.zeros(num_embeddings, embedding_dim, dtype=dtype) * self.init_merger_values[i]
+            torch.zeros(num_embeddings, embedding_dim, dtype=dtype),
+            requires_grad=False  # Freeze embeddings
         ) for i in range(num_models)])
 
     # Method to compute the combined embedding for the merged layer
@@ -279,7 +285,8 @@ class DAMRMSNorm(DAMBaseLayer):
 
         # Initialize the list of weights for each model's layer normalization
         self.weights = nn.ParameterList([Parameter(
-            torch.ones(normalized_shape, dtype=dtype) * self.init_merger_values[i]
+            torch.ones(normalized_shape, dtype=dtype),
+            requires_grad=False  # Freeze weights
         ) for i in range(num_models)])
 
     # Method to compute the combined weight for the merged layer normalization

--- a/dam/modeling/mistral/config.py
+++ b/dam/modeling/mistral/config.py
@@ -123,9 +123,11 @@ class MergedMistralConfig(PretrainedConfig):
         init_merger_values=[],
         use_tanh=False,
         model_index=None,
-        dam_embedding_layer=False,
-        dam_layernorms=False,
-        uses_base_model=False,
+        dam_embedding_layer=True,
+        dam_layernorms=True,
+        uses_base_model=True,
+        is_embedding_coef_trainable=False,
+        is_norm_coef_trainable=False,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -155,6 +157,8 @@ class MergedMistralConfig(PretrainedConfig):
         self.dam_embedding_layer = dam_embedding_layer
         self.dam_layernorms = dam_layernorms
         self.uses_base_model = uses_base_model
+        self.is_embedding_coef_trainable = is_embedding_coef_trainable
+        self.is_norm_coef_trainable = is_norm_coef_trainable
 
         super().__init__(
             pad_token_id=pad_token_id,


### PR DESCRIPTION
 Trainable/Freezable Layer Norm, Embedding Coefficients and Seamless Logits Computation on-the-fly

This PR enhances the model merging process by introducing the ability to pass trainable layer norm coefficients and embedding metrics. The update allows users to control whether these components should be trainable or fixed, improving flexibility and mitigating performance degradation when fine-tuning specific layers.

### Key Features:
- **Trainable Layer Norm Coefficients**:
  - A new flag, `is_norm_coef_trainable`, enables users to specify whether layer norm coefficients are trainable.
  - If set to `True`, the coefficients are updated during training. If `False`, constant values are used, ensuring that unnecessary fine-tuning does not degrade performance.

- **Trainable Embedding Coefficients**:
  - The flag `is_embedding_coef_trainable` offers similar control over embedding layers, allowing users to train these layers or keep them fixed, depending on the specific needs of their model.

- **Efficient Logit Computation**:
  - This PR also streamlines the training pipeline by removing the need for logit computation during training, making the process more seamless and efficient, especially for large-scale models.
