### PR TITLE
Changed save_pretrained to account for safetensors error

### DIFF
--- a/dam/merge.py
+++ b/dam/merge.py
@@ -9,7 +9,6 @@ from glom import glom, Assign
 from tqdm import tqdm
 from huggingface_hub import HfApi
 from itertools import combinations
-from safetensors.torch import load_model, save_model
 
 os.environ['HF_HUB_ENABLE_HF_TRANSFER'] = '1'
 

--- a/dam/merge.py
+++ b/dam/merge.py
@@ -9,6 +9,7 @@ from glom import glom, Assign
 from tqdm import tqdm
 from huggingface_hub import HfApi
 from itertools import combinations
+from safetensors.torch import load_model, save_model
 
 os.environ['HF_HUB_ENABLE_HF_TRANSFER'] = '1'
 
@@ -212,7 +213,7 @@ def merge_models(base_model_id,
     print(f"Total number of trainable parameters: {num_trainable_params}")
 
     print(f"Saving merged model to {output_path}")
-    merged_model.save_pretrained(output_path)
+    merged_model.save_model(output_path)
     tokenizer.save_pretrained(output_path)
 
     fixed_config_path = fix_config(output_path, num_models=len(models), non_linearity=non_linearity, merge_embedding_layers=merge_embedding_layers, merge_layernorms=merge_layernorms, uses_base_model=use_base_model)


### PR DESCRIPTION
Regarding issue #41 RuntimeError During Merging Process Possibly Due to Shared Memory Tensors:
To overcome issues with safetensors in merged pretrained model saving:
- Changed merged_model.save_pretrained(output_path) to merged_model.save_model(output_path).
- Added "from safetensors.torch import load_model, save_model".

This is in alignment with Hugging Face Documentation here: https://huggingface.co/docs/safetensors/torch_shared_tensors