### PR TITLE
safetensors off for saving merged llama models

### DIFF
--- a/dam/merge.py
+++ b/dam/merge.py
@@ -9,6 +9,7 @@ from glom import glom, Assign
 from tqdm import tqdm
 from huggingface_hub import HfApi
 from itertools import combinations
+from transformers import AutoConfig
 
 os.environ['HF_HUB_ENABLE_HF_TRANSFER'] = '1'
 
@@ -213,14 +214,15 @@ def merge_models(base_model_id,
 
     print(f"Saving merged model to {output_path}")
 
-    config_path = os.path.join(output_path, 'config.json')
-    with open(config_path, 'r') as file:
-        data = json.load(file)
+    # Load model configuration from the Hugging Face Hub and check if it's a mistral or llama model
+    config = AutoConfig.from_pretrained(base_model_id)
+    model_type = config.model_type
+    print("Model type is: ", model_type)
                      
-    if data['model_type'] == "mistral":
+    if model_type == "mistral":
         merged_model.save_pretrained(output_path)
         tokenizer.save_pretrained(output_path)
-    elif data['model_type'] == "llama":
+    elif model_type == "llama":
         merged_model.save_pretrained(output_path, safe_serialization=False)
     #Will need to expand with any additional model architecture compatibility updates
 

--- a/dam/merge.py
+++ b/dam/merge.py
@@ -212,6 +212,11 @@ def merge_models(base_model_id,
     print(f"Total number of trainable parameters: {num_trainable_params}")
 
     print(f"Saving merged model to {output_path}")
+
+    config_path = os.path.join(output_path, 'config.json')
+    with open(config_path, 'r') as file:
+        data = json.load(file)
+                     
     if data['model_type'] == "mistral":
         merged_model.save_pretrained(output_path)
         tokenizer.save_pretrained(output_path)

--- a/dam/merge.py
+++ b/dam/merge.py
@@ -212,8 +212,12 @@ def merge_models(base_model_id,
     print(f"Total number of trainable parameters: {num_trainable_params}")
 
     print(f"Saving merged model to {output_path}")
-    merged_model.save_pretrained(output_path)
-    tokenizer.save_pretrained(output_path)
+    if data['model_type'] == "mistral":
+        merged_model.save_pretrained(output_path)
+        tokenizer.save_pretrained(output_path)
+    elif data['model_type'] == "llama":
+        merged_model.save_pretrained(output_path, safe_serialization=False)
+    #Will need to expand with any additional model architecture compatibility updates
 
     fixed_config_path = fix_config(output_path, num_models=len(models), non_linearity=non_linearity, merge_embedding_layers=merge_embedding_layers, merge_layernorms=merge_layernorms, uses_base_model=use_base_model)
 


### PR DESCRIPTION
Changed save_pretrained to run without safetensors, overcoming merged model save errors for Llama (3.2) Architectures  (noted in issue #41)

Changed method save_pretrained to detect if mistral of llama and if it's llama it is performed without safetensors to overcome the merge model saving issues with the llama 3.2 architecture where save_pretrain goofed safetensor (without breaking the integration with mitral or using save_model which didn't seem to work with original llama.)

for llama labelled models it uses:
merged_model.save_pretrained(output_path, safe_serialization=False)

Tested successful with llama and llama 3.2 models (although llama 3.2 model hangs on the later step 3 training, which I believe is a seperate issue and will be submitted as a seperate issue.) So I believe this works well for the llama class of models